### PR TITLE
use "SELECT ... FOR UPDATE" or "SELECT ... LOCK IN SHARE MODE"

### DIFF
--- a/PDO/DataObject.php
+++ b/PDO/DataObject.php
@@ -67,6 +67,14 @@ class PDO_DataObject
     const WHERE_ONLY = true;
 
     /**
+    * optional modes for find()
+    * FOR_UPDATE => SELECT ... FOR UPDATE
+    * LOCK_IN_SHARE_MODE => SELECT ... LOCK IN SHARE MODE
+    */
+    const FOR_UPDATE = 1;
+    const LOCK_IN_SHARE_MODE = 2;
+
+    /**
      * used by config[portability]
      */
     

--- a/PDO/DataObject.php
+++ b/PDO/DataObject.php
@@ -958,10 +958,11 @@ class PDO_DataObject
      * 
      * @return string the SQL select query built from the properties.
      * @param boolean flag to block recusive calling of unions..
+     * @param integer select mode
      * @access public
      */
     
-    final function toSelectSQL($unions = true)
+    final function toSelectSQL($unions = true, $mode=0)
     {
         $quoteIdentifiers = self::$config['quote_identifiers'];
         
@@ -981,7 +982,20 @@ class PDO_DataObject
             ($this->_query['having']    == '' ? '' : $this->_query['having'] . " \n")
         );
 
-        
+
+	if (!in_array($mode, array(0, self::FOR_UPDATE, self::LOCK_IN_SHARE_MODE))) {
+		return $this->raise(
+			"Invalid mode passed to toSelectSQL()",
+			self::ERROR_INVALIDARGS);
+
+	} elseif ($mode == self::FOR_UPDATE) {
+		$sql .= ' FOR UPDATE';
+
+	} elseif ($mode == self::LOCK_IN_SHARE_MODE) {
+		$sql .= ' LOCK IN SHARE MODE';
+
+	}
+
         // derive table.. not sure how well this is really supported...??
         if (!empty($this->_query['derive_table']) && !empty($this->_query['derive_select']) ) {
             

--- a/PDO/DataObject.php
+++ b/PDO/DataObject.php
@@ -1043,10 +1043,11 @@ class PDO_DataObject
      * 
      * @throws PDO_DataObject_Exception - if run twice on the same object, or tablename missing in class.
      * @param   boolean $n Fetch first result
+     * @param   integer $mode
      * @access  public
      * @return  mixed (number of rows returned, or true if numRows fetching is not supported)
      */
-    final function find($n = false)
+    final function find($n = false, $mode=0)
     {
         
         if ($this->_query === false) {
@@ -1077,8 +1078,14 @@ class PDO_DataObject
         
        
         $DB = $this->PDO();
-        
-        $sql = $this->toSelectSQL();
+
+	if (!in_array($mode, array(0, self::FOR_UPDATE, self::LOCK_IN_SHARE_MODE))) {
+		return $this->raise(
+			"Invalid mode passed to find()",
+			self::ERROR_INVALIDARGS);
+	}
+
+        $sql = $this->toSelectSQL(false, $mode);
         
      
         

--- a/README.md
+++ b/README.md
@@ -5,23 +5,27 @@ PDO replacement for PEAR's DB_DataObject
 Work has been funded by CentralNic Group plc 
 
 In General, this should be API compatible with DB_DataObject, except for
-* getDatabaseConnection(), which is replaced with PDOConnection() - and returns a PDO object, rather than a PEAR DB object.
-* staticGet() - has been removed
-* array of database (like a pool is no longer supported) - use a DB proxy
+
+ * getDatabaseConnection(), which is replaced with PDOConnection() - and returns a PDO object, rather than a PEAR DB object.
+ * staticGet() - has been removed
+ * array of database (like a pool is no longer supported) - use a DB proxy
 
 Other Changes
-a) chained methods (prefixed with 'c', and throw exceptions)
+a) chained methods have been added, and some methods have chained wrappers. 
+```
 $key_value =  DB_DAtaObject::Factory('table')
-      ->cautoJoin()
-      ->cwhere('A=12')
-      ->climit(0,10)
-      ->fetchAll('id','name');
-
-b) Default behaviour is to throw exceptions (compatibility - PEAR::Error is available as a setting)
+      ->joinAll()
+      ->where('A=12')
+      ->limit(0,10)
+      ->fetchAll(function() { print_R($this); });
+```
+b) PEAR::Error has been replaced with Exceptions 
 
 c) Overloading has been removed - you should be able to wrap the DataObject and add it back in (it's not recommended - causes more problems than it solves)
 
-d) You can configure DataObjects direct by setting PDO_DataObject::$config - (if PEAR is not loaded, then PEAR::getStaticPropery will not be called...)
+d) You can configure DataObjects direct by calling PDO_DataObject::config()
+
+# See the migration document - at present that contains the most information.
 
 ---------------------
 Commit Log

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ PDO replacement for PEAR's DB_DataObject
 
 Work has been funded by CentralNic Group plc 
 
+# Installation
+
+```
+sudo pear channel-discover roojs.github.com/pear-channel
+sudo pear install roojs/PDO_DataObject-0.0.1
+```
+composer comming soon...
+
+# Notes
+
+
 In General, this should be API compatible with DB_DataObject, except for
 
  * getDatabaseConnection(), which is replaced with PDOConnection() - and returns a PDO object, rather than a PEAR DB object.


### PR DESCRIPTION
It would be useful to be able to specify that rows selected using `find()` should be locked in anticipation of a future `update()`. This pull request adds an optional second argument to `find()` which can be used to do so.

Example usage:

```
class User extends PDO_DataObject {
...
}

$user = new User;
$user->id = "example";
$user->find(true, PDO_DataObject::LOCK_IN_SHARE_MODE);

$user->last_seen = gmdate('r');
$user->update();
```

Documentation on the "SELECT ... FOR UPDATE" and "SELECT ... LOCK IN SHARE MODE" options:

* http://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
* https://www.techonthenet.com/oracle/cursors/for_update.php
* https://www.postgresql.org/docs/9.0/static/sql-select.html#SQL-FOR-UPDATE-SHARE

Note: not done much testing. Also not sure how portable these options are.