### PR TITLE
Fix table generator issues for mysql

### DIFF
--- a/PDO/DataObject/createTables.php
+++ b/PDO/DataObject/createTables.php
@@ -57,6 +57,7 @@ foreach($config as $class=>$values) {
                 
         default:
             // skip... just ingore stuff..
+    }
 }
 
 


### PR DESCRIPTION
@roojs This PR fixes 3 issue:

- syntax error in createTable
- prevents generating double entries in schema file, when multiple indexes exist over same column
- detection of boolean fields, as old DB_DataObject was returning 1 for int(1) while the PDO version returns 10