### PR TITLE
Fix serialize warnings on PHP8

### DIFF
--- a/PDO/DataObject.php
+++ b/PDO/DataObject.php
@@ -6143,13 +6143,23 @@ class PDO_DataObject
     }
 
     /**
-     * To enable serialization of a PDO object we must only store public
+     * To enable serialization of a PDO object we must only store public non-static
      * properties, excluding PDOStatements.
      *
      * @return array
      */
     public function __sleep()
     {
-        return array_keys(get_object_vars($this));
+        $reflection = new ReflectionClass($this);
+        $properties = array_filter(
+            $reflection->getProperties(ReflectionProperty::IS_PUBLIC),
+            function ($property) {
+                return !$property->isStatic();
+            }
+        );
+
+        return array_map(function($prop) {
+            return $prop->getName();
+        }, $properties);
     }
 }


### PR DESCRIPTION
Fixes warning similar to:
E_WARNING: serialize(): \"_query\" returned as member variable from __sleep() but does not exist

This is caused by the fact that _sleep() returns keys available in its context, which are not actually public and non-static.