### PR TITLE
Fix: autoincrement key not properly typecasted

### DIFF
--- a/PDO/DataObject.php
+++ b/PDO/DataObject.php
@@ -2674,10 +2674,11 @@ class PDO_DataObject
         // now do we have an integer key!
 
         if ($key && $useNative) {
+            $insertId = null;
             switch ($dbtype) {
                 case 'mysql':
                 case 'sqlite': // possibly...
-                    $this->$key = $PDO->lastInsertId();
+                    $insertId = $PDO->lastInsertId();
                     break;
 
                 case 'mssql':
@@ -2687,7 +2688,7 @@ class PDO_DataObject
                     // $db->insert();
                     // $db->query('COMMIT');
                     $res = $PDO->query("SELECT @@IDENTITY");
-                    $this->$key = $res->fetchAll(PDO::FETCH_COLUMN, 0)[0]; // could throw error...
+                    $insertId = $res->fetchAll(PDO::FETCH_COLUMN, 0)[0]; // could throw error...
 
                     break;
 
@@ -2696,10 +2697,15 @@ class PDO_DataObject
                         $this->raise("Could not determine Sequence name for table: " . $this->tableName(),
                                           self::ERROR_INVALIDCONFIG);
                     }
-                    $this->$key = $PDO->lastInsertId($seq); // hopefully...
+                    $insertId = $PDO->lastInsertId($seq); // hopefully...
 
                     break;
 
+            }
+            
+            // Use fromValue to properly cast the ID according to column type
+            if ($insertId !== null) {
+                $this->fromValue($key, $insertId);
             }
 
         }
@@ -5684,7 +5690,7 @@ class PDO_DataObject
                 if (!is_numeric($value)) {
                     return "Error: $col : type is INT -> Non numeric '$value' passed to it";
                 }
-                $this->$col = $value;
+                $this->$col = (int) $value;
                 return true;
 
             // todo : floats numerics and ints...


### PR DESCRIPTION
We have identified that there is a mismatch when working with the autoincrement IDs, depending on case.

After inserting a new object the autoincrement key is always set to a string.
After loading an object from the DB the autoincrement key is an integer.

This obviously has quite the impact when using strict comparison `===`.