### PR TITLE
Refactor: Split exception classes into separate files

### DIFF
--- a/PDO/DataObject/Exception.php
+++ b/PDO/DataObject/Exception.php
@@ -22,7 +22,15 @@
  * @link       http://pear.php.net/package/PDO_DataObject
  */
   
- 
+
+class_exists('PDO_DataObject_Exception_InvalidArgs') ? '' : require_once 'PDO/DataObject/Exception/InvalidArgs.php';
+class_exists('PDO_DataObject_Exception_NoData') ? '' : require_once 'PDO/DataObject/Exception/NoData.php';
+class_exists('PDO_DataObject_Exception_InvalidConfig') ? '' : require_once 'PDO/DataObject/Exception/InvalidConfig.php';
+class_exists('PDO_DataObject_Exception_NoClass') ? '' : require_once 'PDO/DataObject/Exception/NoClass.php';
+class_exists('PDO_DataObject_Exception_Set') ? '' : require_once 'PDO/DataObject/Exception/Set.php';
+class_exists('PDO_DataObject_Exception_Connect') ? '' : require_once 'PDO/DataObject/Exception/Connect.php';
+class_exists('PDO_DataObject_Exception_Query') ? '' : require_once 'PDO/DataObject/Exception/Query.php';
+
 class PDO_DataObject_Exception extends Exception
 {
     
@@ -48,14 +56,4 @@ class PDO_DataObject_Exception extends Exception
     
      
 }
-
-// child classes - so you can catch them..
-class PDO_DataObject_Exception_InvalidArgs extends   PDO_DataObject_Exception {};
-class PDO_DataObject_Exception_NoData extends   PDO_DataObject_Exception {};
-class PDO_DataObject_Exception_InvalidConfig extends   PDO_DataObject_Exception {};
-class PDO_DataObject_Exception_NoClass extends   PDO_DataObject_Exception {};
-class PDO_DataObject_Exception_Set extends   PDO_DataObject_Exception {};
-class PDO_DataObject_Exception_Connect extends   PDO_DataObject_Exception {};
-class PDO_DataObject_Exception_Query extends   PDO_DataObject_Exception {};
-
 

--- a/PDO/DataObject/Exception/Connect.php
+++ b/PDO/DataObject/Exception/Connect.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PDO_DataObject_Exception_Connect
+ *
+ * PHP versions 4 and 5
+ *
+ * LICENSE: This source file is subject to version 3.01 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_01.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   Database
+ * @package    PDO_DataObject
+ * @author     Alan Knowles <alan@akbkhome.com>
+ * @copyright  1997-2006 The PHP Group
+ * @license    http://www.php.net/license/3_01.txt  PHP License 3.01
+ * @version    CVS: $Id: Error.php 339237 2016-05-26 03:59:27Z alan_k $
+ * @link       http://pear.php.net/package/PDO_DataObject
+ */
+
+ class_exists('PDO_DataObject_Exception') ? '' : require_once 'PDO/DataObject/Exception.php';
+
+class PDO_DataObject_Exception_Connect extends PDO_DataObject_Exception {}
+

--- a/PDO/DataObject/Exception/InvalidArgs.php
+++ b/PDO/DataObject/Exception/InvalidArgs.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PDO_DataObject_Exception_InvalidArgs
+ *
+ * PHP versions 4 and 5
+ *
+ * LICENSE: This source file is subject to version 3.01 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_01.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   Database
+ * @package    PDO_DataObject
+ * @author     Alan Knowles <alan@akbkhome.com>
+ * @copyright  1997-2006 The PHP Group
+ * @license    http://www.php.net/license/3_01.txt  PHP License 3.01
+ * @version    CVS: $Id: Error.php 339237 2016-05-26 03:59:27Z alan_k $
+ * @link       http://pear.php.net/package/PDO_DataObject
+ */
+
+require_once 'PDO/DataObject/Exception.php';
+
+class PDO_DataObject_Exception_InvalidArgs extends PDO_DataObject_Exception {}
+

--- a/PDO/DataObject/Exception/InvalidConfig.php
+++ b/PDO/DataObject/Exception/InvalidConfig.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PDO_DataObject_Exception_InvalidConfig
+ *
+ * PHP versions 4 and 5
+ *
+ * LICENSE: This source file is subject to version 3.01 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_01.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   Database
+ * @package    PDO_DataObject
+ * @author     Alan Knowles <alan@akbkhome.com>
+ * @copyright  1997-2006 The PHP Group
+ * @license    http://www.php.net/license/3_01.txt  PHP License 3.01
+ * @version    CVS: $Id: Error.php 339237 2016-05-26 03:59:27Z alan_k $
+ * @link       http://pear.php.net/package/PDO_DataObject
+ */
+
+require_once 'PDO/DataObject/Exception.php';
+
+class PDO_DataObject_Exception_InvalidConfig extends PDO_DataObject_Exception {}
+

--- a/PDO/DataObject/Exception/NoClass.php
+++ b/PDO/DataObject/Exception/NoClass.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PDO_DataObject_Exception_NoClass
+ *
+ * PHP versions 4 and 5
+ *
+ * LICENSE: This source file is subject to version 3.01 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_01.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   Database
+ * @package    PDO_DataObject
+ * @author     Alan Knowles <alan@akbkhome.com>
+ * @copyright  1997-2006 The PHP Group
+ * @license    http://www.php.net/license/3_01.txt  PHP License 3.01
+ * @version    CVS: $Id: Error.php 339237 2016-05-26 03:59:27Z alan_k $
+ * @link       http://pear.php.net/package/PDO_DataObject
+ */
+
+require_once 'PDO/DataObject/Exception.php';
+
+class PDO_DataObject_Exception_NoClass extends PDO_DataObject_Exception {}
+

--- a/PDO/DataObject/Exception/NoData.php
+++ b/PDO/DataObject/Exception/NoData.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PDO_DataObject_Exception_NoData
+ *
+ * PHP versions 4 and 5
+ *
+ * LICENSE: This source file is subject to version 3.01 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_01.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   Database
+ * @package    PDO_DataObject
+ * @author     Alan Knowles <alan@akbkhome.com>
+ * @copyright  1997-2006 The PHP Group
+ * @license    http://www.php.net/license/3_01.txt  PHP License 3.01
+ * @version    CVS: $Id: Error.php 339237 2016-05-26 03:59:27Z alan_k $
+ * @link       http://pear.php.net/package/PDO_DataObject
+ */
+
+require_once dirname(__FILE__) . '/../Exception.php';
+
+class PDO_DataObject_Exception_NoData extends PDO_DataObject_Exception {}
+

--- a/PDO/DataObject/Exception/Query.php
+++ b/PDO/DataObject/Exception/Query.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PDO_DataObject_Exception_Query
+ *
+ * PHP versions 4 and 5
+ *
+ * LICENSE: This source file is subject to version 3.01 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_01.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   Database
+ * @package    PDO_DataObject
+ * @author     Alan Knowles <alan@akbkhome.com>
+ * @copyright  1997-2006 The PHP Group
+ * @license    http://www.php.net/license/3_01.txt  PHP License 3.01
+ * @version    CVS: $Id: Error.php 339237 2016-05-26 03:59:27Z alan_k $
+ * @link       http://pear.php.net/package/PDO_DataObject
+ */
+
+require_once 'PDO/DataObject/Exception.php';
+
+class PDO_DataObject_Exception_Query extends PDO_DataObject_Exception {}
+

--- a/PDO/DataObject/Exception/Set.php
+++ b/PDO/DataObject/Exception/Set.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PDO_DataObject_Exception_Set
+ *
+ * PHP versions 4 and 5
+ *
+ * LICENSE: This source file is subject to version 3.01 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_01.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   Database
+ * @package    PDO_DataObject
+ * @author     Alan Knowles <alan@akbkhome.com>
+ * @copyright  1997-2006 The PHP Group
+ * @license    http://www.php.net/license/3_01.txt  PHP License 3.01
+ * @version    CVS: $Id: Error.php 339237 2016-05-26 03:59:27Z alan_k $
+ * @link       http://pear.php.net/package/PDO_DataObject
+ */
+
+class_exists('PDO_DataObject_Exception') ? '' : require_once 'PDO/DataObject/Exception.php';
+
+class PDO_DataObject_Exception_Set extends PDO_DataObject_Exception {}
+


### PR DESCRIPTION
Split PDO_DataObject_Exception child classes from Exception.php into individual files in PDO/DataObject/Exception/ directory:
- InvalidArgs.php
- NoData.php
- InvalidConfig.php
- NoClass.php
- Set.php
- Connect.php
- Query.php

Each child class now has its own file while maintaining the same class names and namespace structure. The base Exception.php file loads all child classes via require_once to maintain backward compatibility with existing code that uses the factory pattern.

This improves code organization and makes individual exception classes easier to locate and maintain.

Thix fixes the issue where phpstan complains about not finding sub exception classes.