### PR TITLE
Fix PHP 8.5 PDO deprecations, keep compatibility with older PHP

### DIFF
--- a/PDO/DataObject.php
+++ b/PDO/DataObject.php
@@ -606,10 +606,9 @@ class PDO_DataObject
         $opts = array();
         if (!empty($dsn_ar['fragment'])) {
             // options.. |MYSQL_ATTR_INIT_COMMAND=....|
-            $pdo_rc = new ReflectionClass( "PDO" );
             foreach(explode('|', $dsn_ar['fragment']) as $opt) {
                 list($k,$v) = explode('=', $opt);
-                $opts[$pdo_rc->getConstant($k)] = $v;
+                $opts[self::dsnOptionConstant($k)] = $v;
 
             }
         }
@@ -654,6 +653,35 @@ class PDO_DataObject
         return self::$connections[$md5];
     }
 
+    /**
+     * Resolve a PDO option constant by name, as used in DSN fragment options
+     * (eg. |MYSQL_ATTR_INIT_COMMAND=...|).
+     *
+     * Driver-specific constants (MYSQL_*, PGSQL_*, SQLITE_*, OCI_*, ODBC_*, DBLIB_*, FIREBIRD_*)
+     * are deprecated on the base PDO class since PHP 8.5 - resolve them via the Pdo\<Driver>
+     * subclasses (available since PHP 8.4) when possible, falling back to the PDO class
+     * for generic constants and on older PHP versions.
+     */
+    private static function dsnOptionConstant($name)
+    {
+        static $driverClasses = array(
+            'MYSQL'    => 'Pdo\\Mysql',
+            'PGSQL'    => 'Pdo\\Pgsql',
+            'SQLITE'   => 'Pdo\\Sqlite',
+            'OCI'      => 'Pdo\\Oci',
+            'ODBC'     => 'Pdo\\Odbc',
+            'DBLIB'    => 'Pdo\\Dblib',
+            'FIREBIRD' => 'Pdo\\Firebird',
+        );
+
+        foreach ($driverClasses as $prefix => $class) {
+            if (strpos($name, $prefix . '_') === 0 && defined($class . '::' . $name)) {
+                return constant($class . '::' . $name);
+            }
+        }
+
+        return defined('PDO::' . $name) ? constant('PDO::' . $name) : false;
+    }
 
 
 
@@ -3378,9 +3406,15 @@ class PDO_DataObject
             return $this->raise("Could not run Query: " . $result->getMessage(), self::ERROR_QUERY, $result);
         }
 
+        // PDO::MYSQL_ATTR_USE_BUFFERED_QUERY is deprecated since PHP 8.5 in favor of
+        // Pdo\Mysql::ATTR_USE_BUFFERED_QUERY (only available from PHP 8.4 onwards).
+        $mysqlAttrUseBufferedQuery = defined('Pdo\\Mysql::ATTR_USE_BUFFERED_QUERY')
+            ? constant('Pdo\\Mysql::ATTR_USE_BUFFERED_QUERY')
+            : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+
         switch (true) {
             case $dbtype  == 'sqlite':
-            case $pdo->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY) == 0:
+            case $pdo->getAttribute($mysqlAttrUseBufferedQuery) == 0:
                 $no_results = true;
                 break;
 

--- a/PDO/DataObject/Cast.php
+++ b/PDO/DataObject/Cast.php
@@ -61,6 +61,7 @@
 *
 
 */ 
+#[AllowDynamicProperties]
 class PDO_DataObject_Cast {
         
     /**

--- a/PDO/DataObject/Exception.php
+++ b/PDO/DataObject/Exception.php
@@ -23,6 +23,7 @@
  */
   
  
+#[AllowDynamicProperties]
 class PDO_DataObject_Exception extends Exception
 {
     

--- a/PDO/DataObject/Generator/Column.php
+++ b/PDO/DataObject/Generator/Column.php
@@ -28,6 +28,7 @@
  * @version    1.0
  * @link       https://github.com/roojs/PDO_DataObject
  */
+#[AllowDynamicProperties]
 class PDO_DataObject_Generator_Column
 {
    

--- a/PDO/DataObject/Generator/Table.php
+++ b/PDO/DataObject/Generator/Table.php
@@ -29,6 +29,7 @@
  * @link       https://github.com/roojs/PDO_DataObject
  */
    
+#[AllowDynamicProperties]
 class PDO_DataObject_Generator_Table {
    
     /**

--- a/PDO/DataObject/Introspection.php
+++ b/PDO/DataObject/Introspection.php
@@ -31,6 +31,7 @@
  */
   
   
+#[AllowDynamicProperties]
 abstract class PDO_DataObject_Introspection
 {
     /**

--- a/PDO/DataObject/Join.php
+++ b/PDO/DataObject/Join.php
@@ -75,6 +75,7 @@
  *
  *
  */
+#[AllowDynamicProperties]
 class PDO_DataObject_Join {
     
     private $do;

--- a/PDO/DataObject/Links.php
+++ b/PDO/DataObject/Links.php
@@ -42,7 +42,8 @@
  *
  * @package DB_DataObject
  */
-class PDO_DataObject_Links 
+#[AllowDynamicProperties]
+class PDO_DataObject_Links
 {
      /**
      * @property {DB_DataObject}      do   DataObject to apply this to.

--- a/PDO/DataObject/Validate.php
+++ b/PDO/DataObject/Validate.php
@@ -32,6 +32,7 @@
  
 
  
+#[AllowDynamicProperties]
 class PDO_DataObject_Validate
 {
     

--- a/tests/37-buffered.phpt
+++ b/tests/37-buffered.phpt
@@ -35,7 +35,11 @@ echo "\n\n--------\n";
 echo "basic load a big result set\n" ;
 
 
-PDO_DataObject::factory('Events')->PDO()->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+$mysqlAttrUseBufferedQuery = defined('Pdo\\Mysql::ATTR_USE_BUFFERED_QUERY')
+    ? constant('Pdo\\Mysql::ATTR_USE_BUFFERED_QUERY')
+    : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+
+PDO_DataObject::factory('Events')->PDO()->setAttribute($mysqlAttrUseBufferedQuery, false);
  
 $x = PDO_DataObject::factory('Events');
 $x->find();

--- a/tests/includes/PDO_Dummy.php
+++ b/tests/includes/PDO_Dummy.php
@@ -33,14 +33,20 @@ class PDO_Dummy {
     function getAttribute($key)
     {
         
+        // PDO::MYSQL_ATTR_USE_BUFFERED_QUERY is deprecated since PHP 8.5 in favor of
+        // Pdo\Mysql::ATTR_USE_BUFFERED_QUERY (only available from PHP 8.4 onwards).
+        $mysqlAttrUseBufferedQuery = defined('Pdo\\Mysql::ATTR_USE_BUFFERED_QUERY')
+            ? constant('Pdo\\Mysql::ATTR_USE_BUFFERED_QUERY')
+            : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+
         switch($key) {
             case PDO::ATTR_DRIVER_NAME:
                 // it does this alot!!!?
                 //echo __FUNCTION__ . '==' .  json_encode(func_get_args()) . " => " . $this->_dbtype  . "\n";
                 return $this->_dbtype;
                 break;
-            
-            case PDO::MYSQL_ATTR_USE_BUFFERED_QUERY:
+
+            case $mysqlAttrUseBufferedQuery:
                 return 1;
             
             default:


### PR DESCRIPTION
Hi @roojs, we are trying to update to the newer PHP version, and we've run into quite a few deprecations coming from PDO_DataObject. Could you please review the below fix? Greatly appreciated.
  
PHP 8.5 deprecates driver-specific constants defined on the base PDO class in favor of the Pdo\<Driver> subclasses added in PHP 8.4. Resolve PDO::MYSQL_ATTR_USE_BUFFERED_QUERY and DSN fragment option constants (eg. MYSQL_ATTR_INIT_COMMAND) conditionally so the library keeps working unchanged on PHP < 8.4 while avoiding the new deprecation notices.

Also add #[AllowDynamicProperties] to several classes that were still missing it, which have been raising dynamic-property deprecations since PHP 8.2.